### PR TITLE
Updated Broken Links in Documentation

### DIFF
--- a/book/run/run-a-node.md
+++ b/book/run/run-a-node.md
@@ -12,4 +12,4 @@ In this chapter we'll go through a few different topics you'll encounter when ru
 1. [Ports](./ports.md)
 1. [Troubleshooting](./troubleshooting.md)
 
-In the future, we also intend to support the [OP Stack](https://docs.optimism.io/stack/getting-started), which will allow you to run Reth as a Layer 2 client. More there soon!
+In the future, we also intend to support the [OP Stack](https://docs.optimism.io/superchain/superchain-explainer), which will allow you to run Reth as a Layer 2 client. More there soon!

--- a/book/run/run-a-node.md
+++ b/book/run/run-a-node.md
@@ -12,4 +12,4 @@ In this chapter we'll go through a few different topics you'll encounter when ru
 1. [Ports](./ports.md)
 1. [Troubleshooting](./troubleshooting.md)
 
-In the future, we also intend to support the [OP Stack](https://stack.optimism.io/docs/understand/explainer/), which will allow you to run Reth as a Layer 2 client. More there soon!
+In the future, we also intend to support the [OP Stack](https://docs.optimism.io/stack/getting-started), which will allow you to run Reth as a Layer 2 client. More there soon!


### PR DESCRIPTION
**What changed? Why?**  
Fixed an outdated link in the `run-a-node.md` file, replacing the old **OP Stack** reference with the correct documentation URL. This ensures users are directed to the latest and most relevant information.

**Files Updated:**

- `book/run/run-a-node.md`
    - Updated OP Stack link from `https://stack.optimism.io/docs/understand/explainer/` to `https://docs.optimism.io/superchain/superchain-explainer`.

**Notes to Reviewers**  
This PR contains a minor documentation update to correct a broken link. No functional changes were made.

**How has it been tested?**

- Verified that the new OP Stack link correctly redirects to the intended documentation.
- Checked markdown formatting for accuracy.